### PR TITLE
Update ViewController.swift

### DIFF
--- a/jamf-migrator/ViewController.swift
+++ b/jamf-migrator/ViewController.swift
@@ -2741,7 +2741,7 @@ class ViewController: NSViewController, URLSessionDelegate, NSTableViewDelegate,
         if LogLevel.debug { WriteToLog().message(stringOfText: "[endPointByID] enter\n") }
         
         saveRawXml      = xmlPrefOptions["saveRawXml"]!
-        saveRawXmlScope = xmlPrefOptions["saveRawXmlScope"]!
+        saveRawXmlScope = xmlPrefOptions["saveRawXmlScope"] ?? false
 
         URLCache.shared.removeAllCachedResponses()
         if LogLevel.debug { WriteToLog().message(stringOfText: "[endPointByID] endpoint passed to endPointByID: \(endpoint)\n") }


### PR DESCRIPTION
Line 2744 is forcefully unwrapping the value from the dictionary (xmlPrefOptions). We are seeing crashes where the key (saveRawXmlScope) does not exist. Ideally should check if a value is returned before unwrapping. Here I have used the Nil Coalescing Operator to supply a default value of false if the key is not found. You could have used an if/let statement as well.